### PR TITLE
Remove label validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@ const RallyValidate = require('./lib/RallyValidate')
 module.exports = app => {
   const handler = new RallyValidate(app)
 
-  app.on(['pull_request.opened', 'pull_request.labeled',
-    'pull_request.unlabeled', 'pull_request.edited',
+  app.on(['pull_request.opened', 'pull_request.edited',
     'pull_request.reopened', 'pull_request.ready_for_review'],
   async context => handler.handlePullRequest(context))
 

--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -112,8 +112,6 @@ class RallyValidate {
       rallyArtifacts.titleList = await this.checkPRTitle(context, config, rallyClient)
       // Get the PR body for validation
       rallyArtifacts.bodyList = await this.checkPRBody(context, config, rallyClient)
-      // Get the PR labels for validation
-      rallyArtifacts.labelList = await this.checkPRLabels(context, config, rallyClient)
 
       await this.updateRallyConnections(rallyClient, rallyArtifacts, context.payload.pull_request, config)
     } catch (e) {
@@ -156,10 +154,9 @@ class RallyValidate {
     this.closeArtifactsFromPRBody(context, config, rallyClient)
   }
 
-  createStatusMessage ({ checkPRLabels, checkPRBody, checkPRTitle, checkCommitMessages, statuses, projects, bodyMessage, titleMessage, labelMessage, commitsMessage }) {
+  createStatusMessage ({ checkPRBody, checkPRTitle, checkCommitMessages, statuses, projects, bodyMessage, titleMessage, commitsMessage }) {
     return outdent`This repository requires a valid Rally artifact to be present in the following portions of this pull before merge will be allowed:
 
-    ${checkPRLabels}
     ${checkPRBody}
     ${checkPRTitle}
     ${checkCommitMessages}
@@ -174,7 +171,6 @@ class RallyValidate {
 
     ${bodyMessage}
     ${titleMessage}
-    ${labelMessage}
     ${commitsMessage}
     `
   }
@@ -185,7 +181,6 @@ class RallyValidate {
     const projects = config.rallyProjects.map(project => `- [x] \`${project}\``)
 
     const statusMessageOptions = {
-      checkPRLabels: config.checkPRLabels ? '- [x] Pull Request Labels' : '- [ ] Pull Request Labels',
       checkPRBody: config.checkPRBody ? '- [x] Pull Request Body' : '- [ ] Pull Request Body',
       checkPRTitle: config.checkPRTitle ? '- [x] Pull Request Title' : '- [ ] Pull Request Title',
       checkCommitMessages: config.checkCommitMessages ? '- [x] Commit Messages' : '- [ ] Commit Messages',
@@ -201,10 +196,6 @@ class RallyValidate {
       message: '',
       isSuccess: true
     }
-    let labelResult = {
-      message: '',
-      isSuccess: true
-    }
     let commitsResult = {
       message: '',
       isSuccess: true
@@ -216,54 +207,21 @@ class RallyValidate {
     if (config.checkPRTitle) {
       titleResult = await this.formatTitleMessage(config, rallyArtifacts.titleList)
     }
-    if (config.checkPRLabels) {
-      labelResult = await this.formatLabelMessage(config, rallyArtifacts.labelList)
-    }
     if (config.checkCommitMessages) {
       commitsResult = await this.formatCommitsMessage(config, rallyArtifacts.commits.commitsWithArtifact, rallyArtifacts.commits.commitsWithoutArtifact)
     }
 
-    const isSuccess = (bodyResult.isSuccess && titleResult.isSuccess && labelResult.isSuccess && commitsResult.isSuccess)
+    const isSuccess = (bodyResult.isSuccess && titleResult.isSuccess && commitsResult.isSuccess)
 
     Object.assign(statusMessageOptions, {
       bodyMessage: bodyResult.message,
       titleMessage: titleResult.message,
-      labelMessage: labelResult.message,
       commitsMessage: commitsResult.message
     })
 
     const statusMessage = this.createStatusMessage(statusMessageOptions)
 
     return { statusMessage, isSuccess }
-  }
-
-  /**
-   * Pull Request Labels
-   * Format the check body and/or pull request comment body
-   * with the status of label validation
-   * @param config
-   * @param labelsList
-   */
-  async formatLabelMessage (config, labelsList) {
-    // Default isSuccess to true, then set to fail if matches fail
-    let isSuccess = true
-    // Set the content headers
-    let message = '\n### Label validation\n'
-    // Format the message for labels
-    if (labelsList && labelsList.length > 0) {
-      message += 'The following labels have been applied, with validation status below\n\n'
-      message += '| Artifact | Rally Status | Project | Validation |\n'
-      message += '| --- | --- | --- | --- |\n'
-      labelsList.forEach(artifact => {
-        if (!artifact.isValid) { isSuccess = false }
-        // Append the status to the PR comment
-        message += `| ${artifact.key} | \`${artifact.status}\` | \`${artifact.projectName}\` | ${artifact.statusIcon} \`${artifact.validState}\` |\n`
-      })
-    } else {
-      message += '\n:heavy_exclamation_mark: No valid artifacts were found in the pull request labels'
-      isSuccess = false
-    }
-    return { message, isSuccess }
   }
 
   /**
@@ -449,29 +407,6 @@ class RallyValidate {
     }
   }
 
-  async checkPRLabels (context, config, rallyClient) {
-    if (config.checkPRLabels) {
-      // Create an empty array for storing all valid artifact ID's
-      const artifactKeys = []
-      // Check each label to see if it contains an artifact ID
-      for (const label of context.payload.pull_request.labels) {
-        const artifactKey = this.findArtifact(label.name, config.rallyObjects)
-        if (artifactKey) {
-          artifactKeys.push(...artifactKey)
-        }
-      }
-      // Determine if we found any artifact ID's
-      if (artifactKeys && artifactKeys.length > 0) { // Validate any found artifacts
-        return Promise.all(artifactKeys.map(artifactKey => {
-          return this.validateArtifact(rallyClient, artifactKey, 'prLabel', context.payload.pull_request, config)
-        }))
-      } else {
-        this.robot.log.debug('No artifact found in PR labels')
-      }
-    }
-    return []
-  }
-
   async setStatusPending (context) {
     return context.github.checks.create(context.repo({
       name: 'rally/validator',
@@ -543,9 +478,6 @@ class RallyValidate {
     noConfigMessage += `---
     # Name of the GitHub Check
     checksName: rally/validator
-
-    # Check PR Labels for Rally artifact
-    checkPRLabels: true
 
     # Check PR Body for Rally artifact
     checkPRBody: true
@@ -758,7 +690,7 @@ class RallyValidate {
 
   async updateRallyConnections (rallyClient, rallyArtifacts, pr, config) {
     const commitList = rallyArtifacts.commits.commitsWithArtifact.map(commit => commit.rally)
-    const allArtifacts = [...commitList, ...rallyArtifacts.titleList, ...rallyArtifacts.bodyList, ...rallyArtifacts.labelList]
+    const allArtifacts = [...commitList, ...rallyArtifacts.titleList, ...rallyArtifacts.bodyList]
     const validArtifacts = allArtifacts.filter(artifact => artifact.isValid)
 
     // get a set of Artifacts with unique key value

--- a/probot-rally.yml
+++ b/probot-rally.yml
@@ -2,9 +2,6 @@
 # Name of the GitHub Check
 checksName: rally/validator
 
-# Check PR Labels for Rally story/defect (true | false)
-checkPRLabels: true
-
 # Check PR Body for Rally story/defect (true | false)
 checkPRBody: true
 


### PR DESCRIPTION
As we've been working through use cases and thinking through the use of this integration with Rally, we've realized that using labels to link with specific items in Rally will create a long list of labels in this repository that would make browsing through them unsustainable. This has pull request removes validation on labels in order to avoid incentivizing this anti-pattern. @primetheus, I'd like to get your 👍/👎  on this one specifically because I'd like to tread carefully before removing functionality that users may have already started to use.