### PR TITLE
Remove markdownlint disablement

### DIFF
--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -10,6 +10,5 @@ Fixes #
 -
 
 ## Readiness Checklist
-- [ ] Label as `breaking` if this is a large fundamental change
-- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
+
 - [ ] If this change requires documentation, it has been included in this pull request


### PR DESCRIPTION
## Proposed Changes

- This removes the `markdownlint disable` that was added to the PR template from the super-linter. I think we should remove this as it's confusing to people creating a new PR since the template is used.
- This also removes the `label` requests in the `Readiness Checklist` below because users are not able to label without write access to the repository.

## Readiness Checklist
- [X] Label as `breaking` if this is a large fundamental change
- [X] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
- [X] If this change requires documentation, it has been included in this pull request
