### PR TITLE
Remove project requirement

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -54,6 +54,8 @@ rally:
 
   # Which projects this repo will link to.
   # To have it connect to any project, leave this value blank
+  # Optional - Leave it commented or set to `Any` to allow from any
+  #            project in the workspace
   projects:
     - Sample Project
     - devops-engineering

--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -91,8 +91,7 @@ class RallyValidate {
     let orgConfigResponse = await context.github.repos.getContents({
       owner: context.payload.pull_request.base.repo.owner.login,
       repo: orgConfigRepoName,
-      path: '.github/rally/' + context.payload.pull_request.base.repo.name + '.yml',
-      ref: 'master'
+      path: '.github/rally/' + context.payload.pull_request.base.repo.name + '.yml'
     })
       .catch(() => ({ // Failed to find or open any default config file
         noFile
@@ -104,8 +103,7 @@ class RallyValidate {
       orgConfigResponse = await context.github.repos.getContents({
         owner: context.payload.pull_request.base.repo.owner.login,
         repo: orgConfigRepoName,
-        path: '.github/' + configFile,
-        ref: 'master'
+        path: '.github/' + configFile
       })
         .catch(() => ({ // Failed to find or open any default config file
           noFile

--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -252,7 +252,11 @@ class RallyValidate {
    */
   async processArtifacts (config, rallyArtifacts) {
     const statuses = [...new Set(config.rally.states.map(status => `- [x] \`${status}\``))]
-    const projects = [...new Set(config.rally.projects.map(project => `- [x] \`${project}\``))]
+    if (config.rally.projects) {
+      const projects = [...new Set(config.rally.projects.map(project => `- [x] \`${project}\``))]
+    } else {
+      const projects = [`- [x] \`Any\``]
+    }
 
     const statusMessageOptions = {
       checkPRBody: config.checkPRBody ? '- [x] Pull Request Body' : '- [ ] Pull Request Body',
@@ -853,6 +857,7 @@ class RallyValidate {
 
         let status
         let projectName
+        let validProject
         let validState
         let statusIcon
         let isValid
@@ -865,7 +870,12 @@ class RallyValidate {
           const artifact = queryResponse.Results[0]
           status = artifact.ScheduleState
           projectName = artifact.Project._refObjectName
-          isValid = (config.rally.states.includes(status) && config.rally.projects.includes(projectName))
+          if (config.rally.projects) {
+            validProject = (config.rally.projects.includes('Any') || config.rally.projects.includes(projectName))
+          } else { // skip validation if the user did not set project restrictions
+            validProject = true
+          }
+          isValid = (config.rally.states.includes(status) && validProject)
           validState = isValid ? 'passed' : 'failed'
           statusIcon = isValid ? ':heavy_check_mark:' : ':heavy_exclamation_mark:'
         }

--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -55,6 +55,9 @@ class RallyValidate {
       if (config.rally.api_key) { // Rally API key, to override global default
         rallyAPIKey = config.rally.api_key
       }
+      if (!config.rally.projects || config.rally.projects.length < 1) {
+        config.rally.projects = ['Any']
+      }
     }
 
     const rallyClient = rally({
@@ -252,11 +255,7 @@ class RallyValidate {
    */
   async processArtifacts (config, rallyArtifacts) {
     const statuses = [...new Set(config.rally.states.map(status => `- [x] \`${status}\``))]
-    if (config.rally.projects) {
-      const projects = [...new Set(config.rally.projects.map(project => `- [x] \`${project}\``))]
-    } else {
-      const projects = [`- [x] \`Any\``]
-    }
+    const projects = [...new Set(config.rally.projects.map(project => `- [x] \`${project}\``))]
 
     const statusMessageOptions = {
       checkPRBody: config.checkPRBody ? '- [x] Pull Request Body' : '- [ ] Pull Request Body',
@@ -870,11 +869,7 @@ class RallyValidate {
           const artifact = queryResponse.Results[0]
           status = artifact.ScheduleState
           projectName = artifact.Project._refObjectName
-          if (config.rally.projects) {
-            validProject = (config.rally.projects.includes('Any') || config.rally.projects.includes(projectName))
-          } else { // skip validation if the user did not set project restrictions
-            validProject = true
-          }
+          validProject = (config.rally.projects.includes('Any') || config.rally.projects.includes(projectName))
           isValid = (config.rally.states.includes(status) && validProject)
           validState = isValid ? 'passed' : 'failed'
           statusIcon = isValid ? ':heavy_check_mark:' : ':heavy_exclamation_mark:'

--- a/rally.yml
+++ b/rally.yml
@@ -33,6 +33,8 @@ rally:
 
   # Which projects this repo will link to.
   # To have it connect to any project, leave this value blank
+  # Optional - Leave it commented or set to `Any` to allow from any
+  #            project in the workspace
   projects:
     - Sample Project
     - devops-engineering


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->

<!-- Link to issue if there is one -->
Closes #106 

<!-- Describe what the changes are -->
## Proposed Changes

- Remove requirement for projects to be defined in config

The current config _requires_ the definition of a project
```yaml
rally:
  projects:
    - Project 1
    - Project 2
  workspace: 12345
```

This pull request allows the following settings as well

```yaml
rally:
  projects: 
    - Any
  workspace: 12345
```

```yaml
rally:
  projects: []
  workspace: 12345
```

```yaml
rally:
  workspace: 12345
```

## Readiness Checklist

- [x] If this change requires documentation, it has been included in this pull request

## Reviewer Checklist

- [x] If a functional change has occurred, testing the integration has been performed
- [x] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
