### PR TITLE
Add proxy support to Rally client implementation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,10 @@ PRIVATE_KEY_PATH=.ssh/rally.pem
 # Example: RALLY_SERVER=rally1.example.com
 RALLY_SERVER=https://rally1.rallydev.com
 
+# URL for a proxy to reach Rally
+# RALLY_PROXY=http://proxy.server:8080
+# RALLY_PROXY=http://<USERNAME>:<PASSWORD>@proxy.server:8080
+
 # Username to auth into Rally
 # NOTE: This is not required if you are using an API key, 
 #       which is the preferred method

--- a/.github/README.md
+++ b/.github/README.md
@@ -143,6 +143,7 @@ nohup npm start 2>&1 >> /path/to/output.log &
 - `WEBHOOK_SECRET` - The secret to prevent man in the middle attacks
 - `GHE_HOST` - This is a required field for **GitHub Enterprise Server** implementations (_Example: github.mycompany.com_)
 - `RALLY_SERVER` - URL to connect to **Rally**
+- `RALLY_PROXY` - Proxy URL for connections to Rally from self-hosted integrations
 - `RALLY_USERNAME` - Username to authenticate to **Rally**
 - `RALLY_PASSWORD` - Password to `RALLY_USERNAME` to authenticate to **Rally** (*Note:* `RALLY_API_KEY` is preferred method)
 - `RALLY_API_KEY` - API key to authenticate to **Rally** instead of `RALLY_USERNAME` and `RALLY_PASSWORD`

--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -60,21 +60,41 @@ class RallyValidate {
       }
     }
 
-    const rallyClient = rally({
-      user: rallyUsername, // Required if no api key, defaults to process.env.RALLY_USERNAME
-      pass: rallyPassword, // Required if no api key, defaults to process.env.RALLY_PASSWORD
-      apiKey: rallyAPIKey, // Preferred, required if no user/pass, defaults to process.env.RALLY_API_KEY
-      apiVersion: 'v2.0',  // This is the default and may be omitted
-      server: rallyServer, // This is the default and may be omitted
-      requestOptions: {
-        headers: {
-          'X-RallyIntegrationName': 'Rally + GitHub', // while optional, it is good practice to
-          'X-RallyIntegrationVendor': 'GitHub, Inc',  // provide this header information
-          'X-RallyIntegrationVersion': '1.0'
+    let rallyClient
+
+    if (process.env.RALLY_PROXY !== undefined) {
+      rallyClient = rally({
+        user: rallyUsername, // Required if no api key, defaults to process.env.RALLY_USERNAME
+        pass: rallyPassword, // Required if no api key, defaults to process.env.RALLY_PASSWORD
+        apiKey: rallyAPIKey, // Preferred, required if no user/pass, defaults to process.env.RALLY_API_KEY
+        apiVersion: 'v2.0',  // This is the default and may be omitted
+        server: rallyServer, // This is the default and may be omitted
+        requestOptions: {
+          headers: {
+            'X-RallyIntegrationName': 'Rally + GitHub', // while optional, it is good practice to
+            'X-RallyIntegrationVendor': 'GitHub, Inc',  // provide this header information
+            'X-RallyIntegrationVersion': '1.0'
+          },
+          proxy: process.env.RALLY_PROXY
         }
-        // any additional request options (proxy options, timeouts, etc.)
-      }
-    })
+      })
+    } else {
+      rallyClient = rally({
+        user: rallyUsername, // Required if no api key, defaults to process.env.RALLY_USERNAME
+        pass: rallyPassword, // Required if no api key, defaults to process.env.RALLY_PASSWORD
+        apiKey: rallyAPIKey, // Preferred, required if no user/pass, defaults to process.env.RALLY_API_KEY
+        apiVersion: 'v2.0',  // This is the default and may be omitted
+        server: rallyServer, // This is the default and may be omitted
+        requestOptions: {
+          headers: {
+            'X-RallyIntegrationName': 'Rally + GitHub', // while optional, it is good practice to
+            'X-RallyIntegrationVendor': 'GitHub, Inc',  // provide this header information
+            'X-RallyIntegrationVersion': '1.0'
+          }
+          // any additional request options (proxy options, timeouts, etc.)
+        }
+      })
+    }
 
     return rallyClient
   }

--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -60,8 +60,6 @@ class RallyValidate {
       }
     }
 
-    let rallyClient
-
     const rallyClient = rally({
       user: rallyUsername, // Required if no api key, defaults to process.env.RALLY_USERNAME
       pass: rallyPassword, // Required if no api key, defaults to process.env.RALLY_PASSWORD

--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -62,39 +62,22 @@ class RallyValidate {
 
     let rallyClient
 
-    if (process.env.RALLY_PROXY !== undefined) {
-      rallyClient = rally({
-        user: rallyUsername, // Required if no api key, defaults to process.env.RALLY_USERNAME
-        pass: rallyPassword, // Required if no api key, defaults to process.env.RALLY_PASSWORD
-        apiKey: rallyAPIKey, // Preferred, required if no user/pass, defaults to process.env.RALLY_API_KEY
-        apiVersion: 'v2.0',  // This is the default and may be omitted
-        server: rallyServer, // This is the default and may be omitted
-        requestOptions: {
-          headers: {
-            'X-RallyIntegrationName': 'Rally + GitHub', // while optional, it is good practice to
-            'X-RallyIntegrationVendor': 'GitHub, Inc',  // provide this header information
-            'X-RallyIntegrationVersion': '1.0'
-          },
-          proxy: process.env.RALLY_PROXY
-        }
-      })
-    } else {
-      rallyClient = rally({
-        user: rallyUsername, // Required if no api key, defaults to process.env.RALLY_USERNAME
-        pass: rallyPassword, // Required if no api key, defaults to process.env.RALLY_PASSWORD
-        apiKey: rallyAPIKey, // Preferred, required if no user/pass, defaults to process.env.RALLY_API_KEY
-        apiVersion: 'v2.0',  // This is the default and may be omitted
-        server: rallyServer, // This is the default and may be omitted
-        requestOptions: {
-          headers: {
-            'X-RallyIntegrationName': 'Rally + GitHub', // while optional, it is good practice to
-            'X-RallyIntegrationVendor': 'GitHub, Inc',  // provide this header information
-            'X-RallyIntegrationVersion': '1.0'
-          }
-          // any additional request options (proxy options, timeouts, etc.)
-        }
-      })
-    }
+    const rallyClient = rally({
+      user: rallyUsername, // Required if no api key, defaults to process.env.RALLY_USERNAME
+      pass: rallyPassword, // Required if no api key, defaults to process.env.RALLY_PASSWORD
+      apiKey: rallyAPIKey, // Preferred, required if no user/pass, defaults to process.env.RALLY_API_KEY
+      apiVersion: 'v2.0',  // This is the default and may be omitted
+      server: rallyServer, // This is the default and may be omitted
+      requestOptions: {
+        headers: {
+          'X-RallyIntegrationName': 'Rally + GitHub', // while optional, it is good practice to
+          'X-RallyIntegrationVendor': 'GitHub, Inc',  // provide this header information
+          'X-RallyIntegrationVersion': '1.0'
+        },
+        ...(process.env.RALLY_PROXY !== undefined && { proxy: process.env.RALLY_PROXY })
+        // any additional request options (proxy options, timeouts, etc.)
+      }
+    })
 
     return rallyClient
   }


### PR DESCRIPTION
## Proposed Changes
This PR adds an environment configuration option to access Rally via a proxy for self-hosted solutions. If the RALLY_PROXY environment variable is set to a proxy address, the [Rally Client](https://github.com/RallyTools/rally-node) will be initialized with the given proxy address.

## Readiness Checklist

- [ ] If this change requires documentation, it has been included in this pull request

## Reviewer Checklist

- [ ] If a functional change has occurred, testing the integration has been performed
- [x] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
