### PR TITLE
Bugfix: Check suite re-run handling

### DIFF
--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -775,13 +775,13 @@ class RallyValidate {
    */
   async rerunCheck (context) {
     const prContext = context
-    
+
     const defaultConfig = await this.getDefaultConfig(context)
     const config = await context.config(configFile, defaultConfig)
     if (!config) {
       await this.setStatusFail(context, this.createNoConfigMessage())
     }
-    
+
     let prNumber
     if (context.name === 'check_suite') {
       prNumber = context.payload.check_suite.pull_requests[0].number

--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -92,9 +92,9 @@ class RallyValidate {
 
     // Get config default from org-level repo .github/rally/<REPO_NAME>.yml
     let orgConfigResponse = await context.github.repos.getContents({
-      owner: context.payload.pull_request.base.repo.owner.login,
+      owner: context.payload.repository.owner.login,
       repo: orgConfigRepoName,
-      path: '.github/rally/' + context.payload.pull_request.base.repo.name + '.yml'
+      path: '.github/rally/' + context.payload.repository.name + '.yml'
     })
       .catch(() => ({ // Failed to find or open any default config file
         noFile
@@ -102,9 +102,9 @@ class RallyValidate {
 
     // Fall back to the default org-level config .github/rally.yml
     if (orgConfigResponse.noFile) {
-      this.robot.log.info('NOTE: config file not found in: ' + orgConfigRepoName + '/.github/rally/' + context.payload.pull_request.base.repo.name + '.yml.')
+      this.robot.log.info('NOTE: config file not found in: ' + orgConfigRepoName + '/.github/rally/' + context.payload.repository.name + '.yml.')
       orgConfigResponse = await context.github.repos.getContents({
-        owner: context.payload.pull_request.base.repo.owner.login,
+        owner: context.payload.repository.owner.login,
         repo: orgConfigRepoName,
         path: '.github/' + configFile
       })
@@ -773,10 +773,16 @@ class RallyValidate {
    * @param config
    * @returns {Promise<void>}
    */
-  async rerunCheck (context, config) {
+  async rerunCheck (context) {
     const prContext = context
+    
+    const defaultConfig = await this.getDefaultConfig(context)
+    const config = await context.config(configFile, defaultConfig)
+    if (!config) {
+      await this.setStatusFail(context, this.createNoConfigMessage())
+    }
+    
     let prNumber
-
     if (context.name === 'check_suite') {
       prNumber = context.payload.check_suite.pull_requests[0].number
       const appId = context.payload.check_suite.app.id

--- a/test/RallyValidate.test.js
+++ b/test/RallyValidate.test.js
@@ -4,6 +4,7 @@ const yaml = require('js-yaml')
 const fs = require('fs')
 
 const validPR = require('./fixtures/valid_pull_request')
+const validRepo = require('./fixtures/valid_repository')
 
 describe('JiraIssueValidate', () => {
   let robot
@@ -50,7 +51,8 @@ describe('JiraIssueValidate', () => {
       },
       repo: jest.fn().mockImplementation((input) => { return input }),
       payload: {
-        pull_request: validPR
+        pull_request: validPR,
+        repository: validRepo
       }
     }
 

--- a/test/fixtures/valid_repository.json
+++ b/test/fixtures/valid_repository.json
@@ -1,0 +1,7 @@
+{
+  "id": 1,
+  "name": "test-repository",
+  "owner": {
+    "login": "rrotaru"
+  }
+}


### PR DESCRIPTION
I noticed that my check re-runs were hanging without completing. It turns out that the `rerunChecks()` handler expected us to pass a `config` argument that is not there. I am updating it to follow the same process as the other PR handlers.

<!-- Describe what the changes are -->
## Proposed Changes

- Add calls to collect config on check re-run event
- Update payload references for check re-run config gathering

## Readiness Checklist

- [x] If this change requires documentation, it has been included in this pull request

## Reviewer Checklist

- [ ] If a functional change has occurred, testing the integration has been performed
- [ ] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
