### PR TITLE
Fix duplicate connections in Rally

### DIFF
--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -982,7 +982,7 @@ class RallyValidate {
         requestOptions: {}
       })
       // Add this PR to the artifact if it hasn't already been added
-      if (!queryResponse.Results.some(result => result.url === pr.html_url)) {
+      if (!queryResponse.Results.some(result => result.Url === pr.html_url)) {
         this.createRallyPullRequest(rallyClient, artifact.artifact._ref, pr)
       }
     })


### PR DESCRIPTION
<!-- Link to issue if there is one -->
Fixes #105 

Looks like we were referencing the URL attribute from the RallyClient payload response incorrectly (it is camelcase `Url` not `url`).

## Readiness Checklist

- [ ] If this change requires documentation, it has been included in this pull request

## Reviewer Checklist

- [ ] If a functional change has occurred, testing the integration has been performed
- [ ] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
