### PR TITLE
Update rally executive sponsor

### DIFF
--- a/ownership.yaml
+++ b/ownership.yaml
@@ -7,7 +7,7 @@ ownership:
     kind: team
     maintainer: primetheus
     team: github/ps-delivery
-    exec_sponsor: dcdrennan
+    exec_sponsor: suekirkmorris
     product_manager: mattcantstop
     repo: https://github.com/github/rally
     mention: github/ps-delivery


### PR DESCRIPTION
## Proposed Changes

The Engineering Fundamentals team is asking that orgs have a single Executive Sponsor for all of their services.  This change sets that to suekirkmorris for the rally service.  Will that work for you?  Thank you.

## Readiness Checklist

- [x] If this change requires documentation, it has been included in this pull request

## Reviewer Checklist

- [ ] If a functional change has occurred, testing the integration has been performed
- [ ] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
