### PR TITLE
Fix misleading validation message

### DIFF
--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -357,7 +357,7 @@ class RallyValidate {
         message += `| ${artifact.key} | \`${artifact.status}\` | \`${artifact.projectName}\` | ${artifact.statusIcon} \`${artifact.validState}\` |\n`
       })
     } else {
-      message += '\n:heavy_exclamation_mark: No valid artifacts were found in the pull request body'
+      message += '\n:heavy_exclamation_mark: No valid artifacts were found in the pull request title'
       isSuccess = false
     }
     return { message, isSuccess }


### PR DESCRIPTION
## Proposed Changes

- If validation of Pull Request Title fails because there was no artifacts in the title, tell the user there were no artifacts in the title, instead of saying there were no artifacts in the body.

## Reviewer Checklist

- [x] If a functional change has occurred, testing the integration has been performed
- [ ] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
