### PR TITLE
fix: commentOnPull

### DIFF
--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -132,6 +132,17 @@ class RallyValidate {
    * @returns {Promise<void>}
    */
   async handlePullRequest (context) {
+    await this.handlePullRequestWithRally (context, this.initializeRallyClient)
+  }
+
+  /**
+   * Process the pull request with the given initializeRallyClient
+   *
+   * @param context
+   * @param _initializeRallyClient
+   * @returns {Promise<void>}
+   */
+  async handlePullRequestWithRally(context, _initializeRallyClient) {
     // Initialize Rally Artifacts
     const rallyArtifacts = {}
 
@@ -155,7 +166,7 @@ class RallyValidate {
     await this.setStatusPending(context, config)
 
     try {
-      const rallyClient = await this.initializeRallyClient(config)
+      const rallyClient = await _initializeRallyClient(config)
       // Get commit comments for validation
       rallyArtifacts.commits = await this.checkCommitMessages(context, config, rallyClient)
       // Get the PR title for validation
@@ -408,8 +419,12 @@ class RallyValidate {
    * @returns {Promise<void>}
    */
   async commentOnPull (context, message) {
-    const params = context.artifact({ body: message })
-    await context.github.artifacts.createComment(params)
+    await context.github.issues.createComment({
+      owner: context.payload.repository.owner.login,
+      repo: context.payload.repository.name,
+      issue_number: context.payload.pull_request.number,
+      body: message
+    })
   }
 
   /**

--- a/rally.yml
+++ b/rally.yml
@@ -15,7 +15,7 @@ checkCommitMessages: true
 mergeOnPRBody: true
 
 # Comment on the PR in addition to the check message? (true | false)
-commentOnPull: false
+commentOnPull: true
 
 rally:
   server: https://rally1.rallydev.com

--- a/rally.yml
+++ b/rally.yml
@@ -15,7 +15,7 @@ checkCommitMessages: true
 mergeOnPRBody: true
 
 # Comment on the PR in addition to the check message? (true | false)
-commentOnPull: true
+commentOnPull: false
 
 rally:
   server: https://rally1.rallydev.com


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->

<!-- Link to issue if there is one -->

<!-- Describe what the changes are -->
## Proposed Changes

`commentOnPull()` used `.artifact()` and `.github.artifacts` that do not exist in `context` in probot v9.14.1.
- those replaced with context.github.issues.createComment, that adds a comment to a PR
- tested in a private installation
- tests updated to inject initializeRallyClient and verify `pull_request.synchronize` flow 

## Readiness Checklist

- [x] If this change requires documentation, it has been included in this pull request

## Reviewer Checklist

- [x] If a functional change has occurred, testing the integration has been performed
- [x] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
