### PR TITLE
fix: await handlePullRequest in rerunCheck and correct asyncs in tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFiles: ['<rootDir>/test/setup.js'],
+};

--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -789,6 +789,17 @@ class RallyValidate {
    * @returns {Promise<void>}
    */
   async rerunCheck (context) {
+    await this.rerunCheckWithRally (context, this.initializeRallyClient)
+  }
+
+  /**
+   * Process the pull request with the given initializeRallyClient
+   *
+   * @param context
+   * @param _initializeRallyClient
+   * @returns {Promise<void>}
+   */
+  async rerunCheckWithRally(context, _initializeRallyClient) {
     const prContext = context
 
     const defaultConfig = await this.getDefaultConfig(context)
@@ -819,7 +830,7 @@ class RallyValidate {
     })
     prContext.payload.pull_request = prResponse.data
 
-    this.handlePullRequest(prContext)
+    await this.handlePullRequestWithRally(prContext, _initializeRallyClient)
   }
 
   /**

--- a/test/fixtures/check_run_rerequested.json
+++ b/test/fixtures/check_run_rerequested.json
@@ -1,0 +1,17 @@
+{
+  "check_run": {
+    "name": "integrations/rally",
+    "check_suite": {
+      "pull_requests": [
+        {
+          "number": 100
+        }
+      ]
+    }
+  },
+  "repository": {
+    "owner": {
+      "login": "acme"
+    }
+  }
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,3 @@
+process.on('unhandledRejection', (err) => {
+  fail(err);
+});


### PR DESCRIPTION
## Proposed Changes
- test 'check_run rerequested' added to test it
- test methods that should be async made async
- commentOnPull made true to also test the appropriate code path
- handlePullRequest in tests replaced with handlePullRequestWithRally to escape creating real rally instance, that runs its own asyncs, that are left after the tesrts are over
- setup.js with fail on unhandledRejection added to catch async warnings like the one appeared with the absent Connections._ref in rallyClient

## Readiness Checklist

- [x] If this change requires documentation, it has been included in this pull request

## Reviewer Checklist

- [x] If a functional change has occurred, testing the integration has been performed
- [ ] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
