### PR TITLE
Correct default org repo documentation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -164,6 +164,7 @@ Once you have the **GitHub App** up and running, users will need to add the conf
 - If a default configuration for all repositories in an organization is desirable, create a `.github/rally.yml` file in a repository called `[ORG_NAME]/.github`. 
     - The name of this configuration repository can also be set as an environment variable (i.e., this bot can look in a repository other than `[ORG_NAME]/.github`).
     - Additionally, if a _per_-repository configuration needs to be managed from this central configuration repository, create such configuration files under a folder named `.github/rally` (e.g., `.github/rally/[REPO_NAME].yml`).
+    - Please note that the `rally.yml` file must still be placed in a `.github` folder, even if the repository itself is named `.github` (at least at the time of [this update](https://github.com/github/rally/blob/68e3294f044999748fdf61cb163ac60531a03ee8/lib/RallyValidate.js#L109)).
 
 ## How to contribute
 We invite you to contribute to this **GitHub App**! Check out [Issues](https://github.com/github/rally/issues) (especially those labeled `help wanted` or `good first issue`) and jump over to [CONTRIBUTING](https://github.com/github/rally/blob/main/.github/CONTRIBUTING.md) for more details.

--- a/.github/README.md
+++ b/.github/README.md
@@ -161,8 +161,9 @@ Once you have the **GitHub App** up and running, users will need to add the conf
 - Having this file in the root of the repository is what signals the **Rally + GitHub App** to view all configured events for the repository
 - The configuration file allows users to make small customizations to how the bot interacts with their codebase
 - Users will also want to configure `protected branches` to help make sure all rules are followed and enforced by the validator bot
-- If a default configuration for all repositories in an organization is desirable, create a `.github/rally.yml` file in a repository called `[ORG_NAME]/rally-github-config`. The name of this configuration repository can also be set as an environment variable.
-- If a _per_-repository configuration needs to be managed from a central repository, create a `.github/rally/[REPO_NAME].yml` file in a repository called `[ORG_NAME]/rally-github-config` instead.
+- If a default configuration for all repositories in an organization is desirable, create a `.github/rally.yml` file in a repository called `[ORG_NAME]/.github`. 
+    - The name of this configuration repository can also be set as an environment variable (i.e., this bot can look in a repository other than `[ORG_NAME]/.github`).
+    - Additionally, if a _per_-repository configuration needs to be managed from this central configuration repository, create such configuration files under a folder named `.github/rally` (e.g., `.github/rally/[REPO_NAME].yml`).
 
 ## How to contribute
 We invite you to contribute to this **GitHub App**! Check out [Issues](https://github.com/github/rally/issues) (especially those labeled `help wanted` or `good first issue`) and jump over to [CONTRIBUTING](https://github.com/github/rally/blob/main/.github/CONTRIBUTING.md) for more details.


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->

<!-- Link to issue if there is one -->
Fixes https://github.com/github/rally/issues/263

<!-- Describe what the changes are -->
## Proposed Changes

- This corrects some inconsistent documentation in the README as documented in https://github.com/github/rally/issues/263
- This also moves the bullet point regarding centralized per-repository configuration under the per-repository configuration bullet point for additional clarity.
- Added clarification around .github folder requirement

![image](https://user-images.githubusercontent.com/4266541/151080525-10d17a39-5718-4f87-9258-d21d3774529e.png)



## Readiness Checklist

- [x] If this change requires documentation, it has been included in this pull request

## Reviewer Checklist

- [ ] If a functional change has occurred, testing the integration has been performed
- [ ] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
