### PR TITLE
fix: Issue#245 Leading and trailing underscores prevent the integration from recognizing valid rally artifacts

### DIFF
--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -724,6 +724,7 @@ class RallyValidate {
 
     prefixes.forEach(prefix => {
       const regexp = RegExp('\\b' + prefix + '[0-9]{1,10}\\b', 'gi')
+      text = text.replaceAll(^/[]a-zA-Z0-9//g, " ")
       const artifactMatches = text.match(regexp)
       if (artifactMatches) {
         artifacts = artifacts.concat(artifactMatches.map(
@@ -766,6 +767,7 @@ class RallyValidate {
       promotionCommands.forEach(command => {
         prefixes.forEach(prefix => {
           const regexp = RegExp('/' + command + ' ' + prefix + '[0-9]{1,10}\\b', 'gi')
+          text = text.replaceAll(^/[]a-zA-Z0-9//g, " ")
           const matches = text.match(regexp)
           if (matches) {
             const artifactMatches = matches.map(match => {


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->

<!-- Link to issue if there is one --> Bug Link : [Leading and trailing underscores prevent the integration from recognizing valid rally artifacts](https://github.com/github/rally/issues/425)
Fixes # Replacing special character so that it can be captured by Rally API

<!-- Describe what the changes are -->
## Proposed Changes

-Fix to accommodate validation for rally artifacts validation in PR with Leading and trailing underscores 

## Readiness Checklist

- [ ] If this change requires documentation, it has been included in this pull request

## Reviewer Checklist

- [x] If a functional change has occurred, testing the integration has been performed
- [x] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
